### PR TITLE
Add option to listen to all network interfaces in cloud env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ coverage/
 
 # OS X generated files and folders
 .DS_Store
+
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ For connections via HTTPS you can define the set of allowed ciphers by setting t
 
   Local and external connections are served via HTTP. **This is insecure!**
 
+`SERVICE_DISCOVERY=cloud` and `TLS_UNPROTECTED=world` together uses one HTTP server for all network interfaces. This is used in cloud scenarios where we have a secure internal network.
+
 ## Technical details
 
 In order to handle traffic coming through the local and the given external interface(s), two server objects will be created: One binds to the local interface, the other one binds to the given external interface(s). Both servers use the same port. This also allows e.g. to use HTTP locally but to encrypt external connections via HTTPS.

--- a/lib/server/create.js
+++ b/lib/server/create.js
@@ -20,6 +20,13 @@ const create = function (options, callback) {
   }
 
   const tlsUnprotected = getenv('TLS_UNPROTECTED', 'loopback');
+  const serviceDiscovery = getenv('SERVICE_DISCOVERY', 'consul');
+
+  const listenToAllInterfaces = (tlsUnprotected === 'world' && serviceDiscovery !== 'consul');
+
+  if (listenToAllInterfaces) {
+    options.host = '0.0.0.0';
+  }
 
   externalAddress(options.host, (err, address) => {
     if (err) {
@@ -59,6 +66,11 @@ const create = function (options, callback) {
 
       default:
         return callback(new Error('TLS_UNPROTECTED invalid.'));
+    }
+
+    if (listenToAllInterfaces) {
+      log.info('Listen to all network interfaces. Do not start extra local http server.');
+      delete networkInterfaces.local;
     }
 
     if (isLocalOnly) {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "docker-host": "3.1.0",
     "eslint-config-seal": "0.0.9",
     "express": "4.15.3",
-    "nodeenv": "0.2.1",
+    "nodeenv": "1.0.0",
     "proxyquire": "1.8.0",
     "roboter": "0.15.3",
     "roboter-server": "0.15.3"

--- a/test/server/consulAdvertiseAddressTest.js
+++ b/test/server/consulAdvertiseAddressTest.js
@@ -64,13 +64,13 @@ suite('consulAdvertiseAddress', () => {
   });
 
   test('queries the advertised address from Consul.', (done) => {
-    nodeenv('CONSUL_URL', `http://${host}:8500`, (restore) => {
-      consulAdvertiseAddress((err, address) => {
-        assert.that(err).is.falsy();
-        assert.that(address).is.matching(/\d+\.\d+\.\d+\.\d+/);
-        restore();
-        done();
-      });
+    const restore = nodeenv('CONSUL_URL', `http://${host}:8500`);
+
+    consulAdvertiseAddress((err, address) => {
+      assert.that(err).is.falsy();
+      assert.that(address).is.matching(/\d+\.\d+\.\d+\.\d+/);
+      restore();
+      done();
     });
   });
 });

--- a/test/server/createTest.js
+++ b/test/server/createTest.js
@@ -47,17 +47,16 @@ suite('create', () => {
 
   test('returns an error if TLS_UNPROTECTED is invalid.', (done) => {
     const app = express();
+    const restore = nodeenv('TLS_UNPROTECTED', 'foo');
 
-    nodeenv('TLS_UNPROTECTED', 'foo', (restore) => {
-      create({
-        app,
-        port: 3000
-      }, (err) => {
-        assert.that(err).is.not.null();
-        assert.that(err.message).is.equalTo('TLS_UNPROTECTED invalid.');
-        restore();
-        done();
-      });
+    create({
+      app,
+      port: 3000
+    }, (err) => {
+      assert.that(err).is.not.null();
+      assert.that(err.message).is.equalTo('TLS_UNPROTECTED invalid.');
+      restore();
+      done();
     });
   });
 
@@ -77,22 +76,21 @@ suite('create', () => {
 
   test('creates only http servers if TLS_UNPROTECTED=world.', (done) => {
     const app = express();
+    const restore = nodeenv('TLS_UNPROTECTED', 'world');
 
-    nodeenv('TLS_UNPROTECTED', 'world', (restore) => {
-      create({
-        app,
-        port: 3000
-      }, (err, interfaces) => {
-        assert.that(err).is.null();
-        assert.that(interfaces.local).is.not.null();
-        assert.that(interfaces.local.server).is.instanceOf(http.Server);
-        assert.that(interfaces.external).is.not.null();
-        assert.that(interfaces.external.server).is.instanceOf(http.Server);
-        interfaces.local.server.close(() => {
-          interfaces.external.server.close(() => {
-            restore();
-            done();
-          });
+    create({
+      app,
+      port: 3000
+    }, (err, interfaces) => {
+      assert.that(err).is.null();
+      assert.that(interfaces.local).is.not.null();
+      assert.that(interfaces.local.server).is.instanceOf(http.Server);
+      assert.that(interfaces.external).is.not.null();
+      assert.that(interfaces.external.server).is.instanceOf(http.Server);
+      interfaces.local.server.close(() => {
+        interfaces.external.server.close(() => {
+          restore();
+          done();
         });
       });
     });
@@ -100,22 +98,21 @@ suite('create', () => {
 
   test('creates https and http servers if TLS_UNPROTECTED=loopback.', (done) => {
     const app = express();
+    const restore = nodeenv('TLS_UNPROTECTED', 'loopback');
 
-    nodeenv('TLS_UNPROTECTED', 'loopback', (restore) => {
-      create({
-        app,
-        port: 3000
-      }, (err, interfaces) => {
-        assert.that(err).is.null();
-        assert.that(interfaces.local).is.not.null();
-        assert.that(interfaces.local.server).is.instanceOf(http.Server);
-        assert.that(interfaces.external).is.not.null();
-        assert.that(interfaces.external.server).is.instanceOf(https.Server);
-        interfaces.local.server.close(() => {
-          interfaces.external.server.close(() => {
-            restore();
-            done();
-          });
+    create({
+      app,
+      port: 3000
+    }, (err, interfaces) => {
+      assert.that(err).is.null();
+      assert.that(interfaces.local).is.not.null();
+      assert.that(interfaces.local.server).is.instanceOf(http.Server);
+      assert.that(interfaces.external).is.not.null();
+      assert.that(interfaces.external.server).is.instanceOf(https.Server);
+      interfaces.local.server.close(() => {
+        interfaces.external.server.close(() => {
+          restore();
+          done();
         });
       });
     });
@@ -123,22 +120,21 @@ suite('create', () => {
 
   test('creates only https servers if TLS_UNPROTECTED=none.', (done) => {
     const app = express();
+    const restore = nodeenv('TLS_UNPROTECTED', 'none');
 
-    nodeenv('TLS_UNPROTECTED', 'none', (restore) => {
-      create({
-        app,
-        port: 3000
-      }, (err, interfaces) => {
-        assert.that(err).is.null();
-        assert.that(interfaces.local).is.not.null();
-        assert.that(interfaces.local.server).is.instanceOf(https.Server);
-        assert.that(interfaces.external).is.not.null();
-        assert.that(interfaces.external.server).is.instanceOf(https.Server);
-        interfaces.local.server.close(() => {
-          interfaces.external.server.close(() => {
-            restore();
-            done();
-          });
+    create({
+      app,
+      port: 3000
+    }, (err, interfaces) => {
+      assert.that(err).is.null();
+      assert.that(interfaces.local).is.not.null();
+      assert.that(interfaces.local.server).is.instanceOf(https.Server);
+      assert.that(interfaces.external).is.not.null();
+      assert.that(interfaces.external.server).is.instanceOf(https.Server);
+      interfaces.local.server.close(() => {
+        interfaces.external.server.close(() => {
+          restore();
+          done();
         });
       });
     });


### PR DESCRIPTION
Problem in Docker Swarm.
The service looks up the IP address that Consul sees and listens only to that interface + localhost.

```
ippcheckin:
    root@ce6fbddd314b:/# curl http://dispatcher:3000
    curl: (7) Failed to connect to dispatcher port 3000: No route to host
    root@ce6fbddd314b:/# 
    root@ce6fbddd314b:/# ping dispatcher
    PING dispatcher (10.0.1.26): 56 data bytes
    64 bytes from 10.0.1.26: icmp_seq=0 ttl=64 time=0.087 ms


dispatcher:
    Proto Recv-Q Send-Q Local Address           Foreign Address         State      
    tcp        0      0 127.0.0.1:3000          0.0.0.0:*               LISTEN     
    tcp        0      0 10.0.1.26:3000          0.0.0.0:*               LISTEN     
    root@954cba39e338:/# ip a
    1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
        link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
        inet 127.0.0.1/8 scope host lo
           valid_lft forever preferred_lft forever
        inet 10.0.1.26/32 brd 10.0.1.26 scope global lo
           valid_lft forever preferred_lft forever
    11857: eth0@if11858: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue state UP group default 
        link/ether 02:42:0a:00:01:32 brd ff:ff:ff:ff:ff:ff
        inet 10.0.1.50/24 brd 10.0.1.255 scope global eth0
           valid_lft forever preferred_lft forever
    11865: eth1@if11866: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default 
        link/ether 02:42:ac:13:00:14 brd ff:ff:ff:ff:ff:ff
        inet 172.19.0.20/16 brd 172.19.255.255 scope global eth1
           valid_lft forever preferred_lft forever
    root@954cba39e338:/# 
```


Solution: In cloud env we do not need two HTTP server, just listen all network interfaces.
